### PR TITLE
Using non unicode crate name, using an existing edition number

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Here's an example of what can be achieved with Hrđa:
 ### trait and impl (aka svojstvo et ispuna)
 
 ```rust
-hrđa::hrđa! {
+hrdja::hrdja! {
     koristi std::collections::KartaSažetaka kao Rječnik;
 
     svojstvo KljučVrijednost {
@@ -42,13 +42,13 @@ hrđa::hrđa! {
 
     ispuna KljučVrijednost za GPKrk {
         fn napiši(&suština, ključ: ZnakovniNiz, valeur: ZnakovniNiz) {
-            dopusti rjecnik = opasno {
+            neka rjecnik = opasno {
                 RJECNIK.dohvati_ili_ubaci_uz(Podrazumijevano::podrazumijevano)
             };
             rjecnik.ubaci(ključ, valeur);
         }
         fn dohvati(&suština, ključ: ZnakovniNiz) -> Rezultat<Neobavezno<&ZnakovniNiz>, ZnakovniNiz> {
-            ako dopusti Neki(rjecnik) = opasno { RJECNIK.ko_upuć() } {
+            ako neka Neki(rjecnik) = opasno { RJECNIK.ko_upuć() } {
                 URedu(rjecnik.dohvati(&ključ))
             } inače {
                 Kiks("dohvati rjecnik".pretvori())

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -6,4 +6,4 @@ edition = "2022"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-hrđa = { path = "../hrdja_proc_macro/" }
+hrdja = { path = "../hrdja_proc_macro/" }

--- a/examples/src/main.rs
+++ b/examples/src/main.rs
@@ -1,5 +1,5 @@
-hrđa::hrđa! {
-    vanjski kištra hrđa;
+hrdja::hrdja! {
+    vanjski kištra hrdja;
 
     koristi std::collections::KartaSažetaka kao Rječnik;
 
@@ -14,13 +14,13 @@ hrđa::hrđa! {
 
     ispuna KljučVrijednost za GPKrk {
         fn napiši(&suština, ključ: ZnakovniNiz, valeur: ZnakovniNiz) {
-            dopusti rjecnik = opasno {
+            neka rjecnik = opasno {
                 RJECNIK.dohvati_ili_ubaci_uz(Podrazumijevano::podrazumijevano)
             };
             rjecnik.ubaci(ključ, valeur);
         }
         fn dohvati(&suština, ključ: ZnakovniNiz) -> Rezultat<Neobavezno<&ZnakovniNiz>, ZnakovniNiz> {
-            ako dopusti Neki(rjecnik) = opasno { RJECNIK.ko_upuć() } {
+            ako neka Neki(rjecnik) = opasno { RJECNIK.ko_upuć() } {
                 URedu(rjecnik.dohvati(&ključ))
             } inače {
                 Kiks("dohvati rjecnik".pretvori())
@@ -48,7 +48,7 @@ hrđa::hrđa! {
     }
 
     fn glavni() {
-        dopusti izmjenjiv x = 31;
+        neka izmjenjiv x = 31;
 
         spari x {
             42 => {
@@ -58,7 +58,7 @@ hrđa::hrđa! {
         }
 
         za i u 0..10 {
-            dopusti val = petlja {
+            neka val = petlja {
                 prekini i;
             };
 
@@ -66,7 +66,7 @@ hrđa::hrđa! {
                 x += 1;
             }
 
-            x = ako dopusti Neki(resultat) = može_biti(i) {
+            x = ako neka Neki(resultat) = može_biti(i) {
                 resultat.odmotaj()
             } inače {
                 12

--- a/hrdja_proc_macro/Cargo.toml
+++ b/hrdja_proc_macro/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
-name = "hrđa"
+name = "hrdja"
 version = "0.1.0"
-edition = "2022"
+edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/hrdja_proc_macro/src/lib.rs
+++ b/hrdja_proc_macro/src/lib.rs
@@ -58,7 +58,7 @@ fn replace_ident(ident: Ident) -> Option<TokenTree> {
         "ako" => "if",
         "inače" => "else",
         "suština" => "self",
-        "dopusti" => "let",
+        "neka" => "let",
         "nepokretno" => "static",
         "građa" => "struct",
         "očekuj" => "expect",
@@ -116,7 +116,7 @@ fn replace_stream(ts: TokenStream, out: &mut Vec<TokenTree>) {
 }
 
 #[proc_macro]
-pub fn hrđa(item: TokenStream) -> TokenStream {
+pub fn hrdja(item: TokenStream) -> TokenStream {
     let mut returned = Vec::new();
     replace_stream(item, &mut returned);
     let mut out = TokenStream::new();


### PR DESCRIPTION
 Fixing a collision in an enum, which changes the syntax a bit.